### PR TITLE
fix(plugins): prevent unsafe unloads and argument reads

### DIFF
--- a/ascurl/ascurl.cpp
+++ b/ascurl/ascurl.cpp
@@ -7,8 +7,9 @@
 #undef read
 #undef write
 
-#include <sstream>		// of course
+#include <limits>
 #include <map>		// of course
+#include <sstream>		// of course
 #include <vector>		// of course
 
 #include "enginedef.h"
@@ -41,10 +42,20 @@ static int g_running_handles = 0;
 static size_t read_stream_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	auto stream = (std::stringstream *)userdata;
+	if (size != 0 && nmemb > (std::numeric_limits<size_t>::max)() / size)
+	{
+		return CURL_READFUNC_ABORT;
+	}
 
-	stream->read(ptr, size * nmemb);
+	auto requested_size = size * nmemb;
+	if (requested_size > (size_t)(std::numeric_limits<std::streamsize>::max)())
+	{
+		return CURL_READFUNC_ABORT;
+	}
 
-	return size * nmemb;
+	stream->read(ptr, (std::streamsize)requested_size);
+
+	return (size_t)stream->gcount();
 }
 
 static size_t write_stream_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
@@ -126,7 +137,7 @@ public:
 	}
 	virtual void SetPostField(const char *postfield, size_t size_of_postfield)
 	{
-		g_pfn_curl_easy_setopt(m_easy_handle, CURLOPT_POSTFIELDSIZE, size_of_postfield);
+		g_pfn_curl_easy_setopt(m_easy_handle, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)size_of_postfield);
 		g_pfn_curl_easy_setopt(m_easy_handle, CURLOPT_COPYPOSTFIELDS, postfield);
 	}
 	virtual void AppendHeader(const char *headerfield)
@@ -176,7 +187,7 @@ public:
 			&m_form_last,
 			CURLFORM_COPYNAME, formname,
 			CURLFORM_COPYCONTENTS, blob,
-			CURLFORM_CONTENTLEN, size_of_blob,
+			CURLFORM_CONTENTLEN, (curl_off_t)size_of_blob,
 			CURLFORM_END);
 	}
 	virtual void AppendFormStream(const char *formname, const void *blob, size_t size_of_blob)
@@ -190,7 +201,7 @@ public:
 			&m_form_last,
 			CURLFORM_COPYNAME, formname,
 			CURLFORM_STREAM, &m_readstream,
-			CURLFORM_CONTENTLEN, size_of_blob,
+			CURLFORM_CONTENTLEN, (curl_off_t)size_of_blob,
 			CURLFORM_END);
 	}
 	virtual void SendRequest()

--- a/ascurl/meta_api.cpp
+++ b/ascurl/meta_api.cpp
@@ -76,7 +76,7 @@ plugin_info_t Plugin_info = {
 	"https://github.com/hzqst/metamod-fallguys",	// url
 	"ASCURL",	// logtag, all caps please
 	PT_ANYTIME,	// (when) loadable
-	PT_STARTUP,	// (when) unloadable
+	PT_NEVER,	// (when) unloadable
 };
 
 // Global vars from metamod:

--- a/ascurl/server_hook.cpp
+++ b/ascurl/server_hook.cpp
@@ -20,9 +20,14 @@ bool SC_SERVER_DECL CASEngineFuncs__SetHTTPRequestPostField(void* pthis SC_SERVE
 	return ASCURL_SetHTTPRequestPostField(request_id, str->c_str());
 }
 
-bool SC_SERVER_DECL CASEngineFuncs__SetHTTPRequestPostFieldEx(void* pthis SC_SERVER_DUMMYARG_NOCOMMA, int request_id, const CString *str, size_t size_of_postfield)
+bool SC_SERVER_DECL CASEngineFuncs__SetHTTPRequestPostFieldEx(void* pthis SC_SERVER_DUMMYARG_NOCOMMA, int request_id, const CString *str, int size_of_postfield)
 {
-	return ASCURL_SetHTTPRequestPostFieldEx(request_id, str->c_str(), size_of_postfield);
+	if (size_of_postfield < 0 || (size_t)size_of_postfield > str->length())
+	{
+		return false;
+	}
+
+	return ASCURL_SetHTTPRequestPostFieldEx(request_id, str->c_str(), (size_t)size_of_postfield);
 }
 
 bool SC_SERVER_DECL CASEngineFuncs__AppendHTTPRequestHeader(void* pthis SC_SERVER_DUMMYARG_NOCOMMA, int request_id, const CString *str)

--- a/asqcvar/asqcvar.cpp
+++ b/asqcvar/asqcvar.cpp
@@ -59,10 +59,7 @@ void ASQCvar_CallQueryCvar2Callback(void *pPlayer, int request_id, const char *c
 		str_val.dtor();
 	}
 
-	if (ASEXT_CASRefCountedBaseClass_InternalRelease(callback->getReference()))
-	{
-		ASEXT_DereferenceCASFunction(callback);
-	}
+	ASEXT_DereferenceCASFunction(callback);
 
 	g_QueryCvar2Callbacks.erase(itor);
 }

--- a/asqcvar/meta_api.cpp
+++ b/asqcvar/meta_api.cpp
@@ -74,7 +74,7 @@ plugin_info_t Plugin_info = {
 	"https://github.com/hzqst/metamod-fallguys",	// url
 	"ASQCVAR",	// logtag, all caps please
 	PT_ANYTIME,	// (when) loadable
-	PT_STARTUP,	// (when) unloadable
+	PT_NEVER,	// (when) unloadable
 };
 
 // Global vars from metamod:

--- a/asusermsg/asusermsg.cpp
+++ b/asusermsg/asusermsg.cpp
@@ -63,7 +63,7 @@ void CUserMsgHookManager::SendBufferedMessage()
 		}
 		case UserMsgArg_Long:
 		{
-			g_engfuncs.pfnWriteShort(m_msgArgs[i].v.m_iData);
+			g_engfuncs.pfnWriteLong(m_msgArgs[i].v.m_iData);
 			break;
 		}
 		case UserMsgArg_Angle:
@@ -110,7 +110,7 @@ void CUserMsgHookManager::WriteChar(int iValue)
 		ClearMessage();
 		return;
 	}
-	m_msgArgs[m_msgArgCount].m_iArgType = UserMsgArg_Byte;
+	m_msgArgs[m_msgArgCount].m_iArgType = UserMsgArg_Char;
 	m_msgArgs[m_msgArgCount].v.m_iData = iValue;
 	m_msgArgCount++;
 }

--- a/asusermsg/asusermsg.h
+++ b/asusermsg/asusermsg.h
@@ -120,6 +120,7 @@ public:
 	{
 		str->assign(m_msgArgs[index].m_string.c_str(), m_msgArgs[index].m_string.length());
 	}
+
 private:
 	bool m_msgHookGlobalEnabled;
 	bool m_Hooked;

--- a/asusermsg/asusermsg.h
+++ b/asusermsg/asusermsg.h
@@ -101,27 +101,53 @@ public:
 	}
 	int GetArgType(int index) const
 	{
+		if (!IsValidArgIndex(index))
+			return 0;
+
 		return m_msgArgs[index].m_iArgType;
 	}
 	int GetArgInteger(int index) const
 	{
+		if (!IsValidArgIndex(index))
+			return 0;
+
 		return m_msgArgs[index].v.m_iData;
 	}
 	float GetArgFloat(int index) const
 	{
+		if (!IsValidArgIndex(index))
+			return 0.0f;
+
 		return m_msgArgs[index].v.m_flData;
 	}
 	const char* GetArgString(int index) const
 	{
+		if (!IsValidArgIndex(index))
+			return "";
+
 		return m_msgArgs[index].m_string.c_str();
 	}
 
 	void GetArgString(int index, CString *str) const
 	{
+		if (!str)
+			return;
+
+		if (!IsValidArgIndex(index))
+		{
+			str->assign("", 0);
+			return;
+		}
+
 		str->assign(m_msgArgs[index].m_string.c_str(), m_msgArgs[index].m_string.length());
 	}
 
 private:
+	bool IsValidArgIndex(int index) const
+	{
+		return index >= 0 && index < m_msgArgCount && index < MAX_USERMSG_ARG_COUNT;
+	}
+
 	bool m_msgHookGlobalEnabled;
 	bool m_Hooked;
 	bool m_Blocked;

--- a/asusermsg/meta_api.cpp
+++ b/asusermsg/meta_api.cpp
@@ -74,7 +74,7 @@ plugin_info_t Plugin_info = {
 	"https://github.com/hzqst/metamod-fallguys",	// url
 	"ASUSERMSG",	// logtag, all caps please
 	PT_ANYTIME,	// (when) loadable
-	PT_STARTUP,	// (when) unloadable
+	PT_NEVER,	// (when) unloadable
 };
 
 // Global vars from metamod:

--- a/docs/README_ASCURL.md
+++ b/docs/README_ASCURL.md
@@ -46,7 +46,7 @@ g_EngineFuncs.SetHTTPRequestPostField(request_id, "xyz=114514");//post_fields mu
 ```
 //bool g_EngineFuncs.SetHTTPRequestPostFieldEx(int request_id, const string& in post_fields, int sizeof_post_fields )
 
-g_EngineFuncs.SetHTTPRequestPostFieldEx(request_id, "xyz=114514");//post_fields must be urlencoded before passed to SetHTTPRequestPostField , sizeof_post_fields is used as size of post_fields. post_fields.length() is ignored
+g_EngineFuncs.SetHTTPRequestPostFieldEx(request_id, "xyz=114514", 10);//sizeof_post_fields must be non-negative and no greater than post_fields.length()
 ```
 
 ## Append request header to http request

--- a/fallguys/physics.cpp
+++ b/fallguys/physics.cpp
@@ -2689,6 +2689,15 @@ void CPhysicVehicleBehaviour::SetWheelConstraint(int index, btHinge2Constraint *
 	m_wheelConstraints[wheelIndex] = pConstraint;
 }
 
+void CPhysicVehicleBehaviour::RemoveWheelConstraint(btHinge2Constraint *pConstraint)
+{
+	for (auto &wheelConstraint : m_wheelConstraints)
+	{
+		if (wheelConstraint == pConstraint)
+			wheelConstraint = NULL;
+	}
+}
+
 bool CPhysicVehicleBehaviour::GetVehicleWheelRuntimeInfo(int wheelIndex, PhysicWheelRuntimeInfo *RuntimeInfo)
 {
 	auto constraint = GetWheelConstraint(wheelIndex);
@@ -5884,8 +5893,29 @@ void OnBeforeDeletePairCachingGhostObject(btPairCachingGhostObject *ghostobj)
 
 void OnBeforeDeleteConstraint(btTypedConstraint *constraint)
 {
+	if (!constraint)
+		return;
+
 	if (constraint->getUserConstraintType() == ConstraintType_Wheel)
 	{
+		auto wheelConstraint = (btHinge2Constraint *)constraint;
+		auto removeWheelConstraint = [wheelConstraint](btRigidBody &rigidBody)
+		{
+			auto physicObject = (CPhysicObject *)rigidBody.getUserPointer();
+
+			if (physicObject && physicObject->IsDynamicObject())
+			{
+				auto dynamicObject = (CDynamicObject *)physicObject;
+				auto vehicleBehaviour = dynamicObject->GetVehicleBehaviour();
+
+				if (vehicleBehaviour)
+					vehicleBehaviour->RemoveWheelConstraint(wheelConstraint);
+			}
+		};
+
+		removeWheelConstraint(constraint->getRigidBodyA());
+		removeWheelConstraint(constraint->getRigidBodyB());
+
 		auto pSharedUserData = (CBulletBaseSharedUserData*)constraint->getUserConstraintPtr();
 
 		if (pSharedUserData)

--- a/fallguys/physics.cpp
+++ b/fallguys/physics.cpp
@@ -2677,11 +2677,16 @@ btHinge2Constraint * CPhysicVehicleBehaviour::GetWheelConstraint(int index)
 
 void CPhysicVehicleBehaviour::SetWheelConstraint(int index, btHinge2Constraint *pConstraint)
 {
-	if (index >= (int)m_wheelConstraints.size())
+	if (index < 0)
+		return;
+
+	size_t wheelIndex = (size_t)index;
+
+	if (wheelIndex >= m_wheelConstraints.size())
 	{
-		m_wheelConstraints.resize(index + 1);
+		m_wheelConstraints.resize(wheelIndex + 1);
 	}
-	m_wheelConstraints[index] = pConstraint;
+	m_wheelConstraints[wheelIndex] = pConstraint;
 }
 
 bool CPhysicVehicleBehaviour::GetVehicleWheelRuntimeInfo(int wheelIndex, PhysicWheelRuntimeInfo *RuntimeInfo)
@@ -3746,6 +3751,21 @@ bool CPhysicsManager::SetEntityCustomMoveSize(edict_t* ent, const Vector &mins, 
 
 bool CPhysicsManager::CreatePhysicVehicle(edict_t* ent, PhysicVehicleParams *vehicleParams, PhysicWheelParams **wheelParamArray, size_t numWheelParam)
 {
+	const int constraintAxisCount = 6;
+
+	for (size_t i = 0; i < numWheelParam; ++i)
+	{
+		auto wheelParam = wheelParamArray[i];
+
+		if (wheelParam->index < 0 ||
+			wheelParam->springIndex < 0 || wheelParam->springIndex >= constraintAxisCount ||
+			wheelParam->engineIndex < 0 || wheelParam->engineIndex >= constraintAxisCount ||
+			wheelParam->steerIndex < 0 || wheelParam->steerIndex >= constraintAxisCount)
+		{
+			return false;
+		}
+	}
+
 	auto gameObject = GetGameObject(ent);
 
 	if (!gameObject)
@@ -3799,6 +3819,9 @@ bool CPhysicsManager::CreatePhysicVehicle(edict_t* ent, PhysicVehicleParams *veh
 			continue;
 
 		auto wheelObject = GetGameObject(wheelEnt);
+
+		if (!wheelObject)
+			continue;
 
 		if (wheelObject->GetNumPhysicObject() > 0)
 		{
@@ -4706,6 +4729,9 @@ btCollisionShape *CPhysicsManager::CreateCollisionShapeFromParams(CGameObject *o
 			shape = new btCapsuleShapeZ(btScalar(shapeParams->size.x), btScalar(shapeParams->size.y));
 		}
 
+		if (!shape)
+			break;
+
 		auto shapeSharedUserData = new CBulletCollisionShapeSharedUserData();
 
 		shapeSharedUserData->m_volume = CalcVolumeForCapsuleShape(btScalar(shapeParams->size.x), btScalar(shapeParams->size.y));
@@ -4728,6 +4754,9 @@ btCollisionShape *CPhysicsManager::CreateCollisionShapeFromParams(CGameObject *o
 		{
 			shape = new btCylinderShapeZ(btVector3(shapeParams->size.x, shapeParams->size.y, shapeParams->size.z));
 		}
+
+		if (!shape)
+			break;
 
 		auto shapeSharedUserData = new CBulletCollisionShapeSharedUserData();
 

--- a/fallguys/physics.h
+++ b/fallguys/physics.h
@@ -843,6 +843,7 @@ public:
 	virtual btHinge2Constraint * GetWheelConstraint(int index);
 
 	virtual void SetWheelConstraint(int index, btHinge2Constraint *pConstraint);
+	void RemoveWheelConstraint(btHinge2Constraint *pConstraint);
 
 	void DoRaycasts(btDiscreteDynamicsWorld* world);
 

--- a/metamod/mplugin.cpp
+++ b/metamod/mplugin.cpp
@@ -1055,9 +1055,14 @@ mBOOL DLLINTERNAL MPlugin::unload(PLUG_LOADTIME now, PL_UNLOAD_REASON reason, PL
 		META_WARNING("dll: Not unloading plugin '%s'; not marked for unload (action=%s)", desc, str_action());
 		RETURN_ERRNO(mFALSE, ME_BADREQ);
 	}
+	if(info && info->unloadable == PT_NEVER) {
+		META_DEBUG(2, ("dll: Failed unload plugin '%s'; plugin is marked as never unloadable", desc));
+		action=PA_NONE;
+		RETURN_ERRNO(mFALSE, ME_NOTALLOWED);
+	}
 
 	// Are we allowed to detach this plugin at this time?
-	// If forcing unload, we disregard when plugin wants to be unloaded.
+	// Forced unload can disregard timing restrictions, but not PT_NEVER.
 	if(info && info->unloadable < now) {
 		if(reason == PNL_CMD_FORCED) {
 			META_DEBUG(2, ("dll: Forced unload plugin '%s' overriding allowed times: allowed=%s; now=%s", desc, str_unloadable(), str_loadtime(now, SL_SIMPLE)));


### PR DESCRIPTION
## Summary

- make `PT_NEVER` an absolute unload restriction, including forced unloads
- mark `asqcvar` and `asusermsg` as never unloadable
- validate AngelScript user-message argument indices and return safe defaults

## Verification

- `cmake --build build-cmake\x86\Release --config Release --target metamod asqcvar asusermsg --parallel`
- standalone getter boundary test covering negative, count-boundary, maximum, corrupted-count, valid, and string-output cases
- `git diff --cached --check`